### PR TITLE
add cnp, make script work and tune cronjob

### DIFF
--- a/helm/pg-cluster-recovery-test/templates/cilium-network-policy.yaml
+++ b/helm/pg-cluster-recovery-test/templates/cilium-network-policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  labels:
+    {{ include "labels.common" . | nindent 4 }}
+  name: {{ .Values.pgCluster.name }}
+  namespace: {{ .Values.pgCluster.namespace }}
+spec:
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        cnpg.io/cluster: {{ .Values.pgCluster.name }}
+    toPorts:
+    - ports:
+      - port: "5432"
+  - toEntities:
+    - world
+    - kube-apiserver
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ .Values.pgCluster.name }}
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        cnpg.io/cluster: {{ .Values.pgCluster.name }}
+    toPorts:
+    - ports:
+      - port: "5432"

--- a/helm/pg-cluster-recovery-test/templates/cronjobs.yaml
+++ b/helm/pg-cluster-recovery-test/templates/cronjobs.yaml
@@ -2,20 +2,20 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:
-    {{ include "labels.common" $ | nindent 4 }}
+    {{ include "labels.common" . | nindent 4 }}
   name: {{ .Values.pgCluster.name }}
   namespace: {{ .Values.pgCluster.namespace }}
 spec:
   jobTemplate:
     metadata:
       labels:
-        {{ include "labels.common" $ | nindent 8 }}
+        {{ include "labels.common" . | nindent 8 }}
     spec:
       backoffLimit: {{ .Values.cronjob.backoffLimit }}
       template:
         metadata:
           labels:
-            {{ include "labels.common" $ | nindent 12 }}
+            {{ include "labels.common" . | nindent 12 }}
         spec:
           containers:
           - command:
@@ -25,7 +25,9 @@ spec:
             name: "pg-cluster-recovery-test"
             env:
             - name: TEST_TIMEOUT
-              value: {{ $.Values.cronjob.testTimeout }}
+              value: {{ .Values.cronjob.testTimeout }}
+            - name: WAIT_TIMEOUT
+              value: {{ .Values.cronjob.waitTimeout }}
             resources:
               {{- toYaml .Values.cronjob.resources | nindent 14 }}
             securityContext:
@@ -42,5 +44,6 @@ spec:
           - name: pg-cluster-recovery-template
             configMap:
               name: {{ .Values.pgCluster.name }}
+              defaultMode: {{ .Values.cronjob.configMap.defaultMode }}
   terminationGracePeriodSeconds: 30
   schedule: {{ .Values.cronjob.schedule }}

--- a/helm/pg-cluster-recovery-test/templates/pg-cluster-configmaps.yaml
+++ b/helm/pg-cluster-recovery-test/templates/pg-cluster-configmaps.yaml
@@ -52,47 +52,64 @@ data:
       serviceAccountTemplate:
         metadata:
           annotations:
-            {{ toYaml .Values.pgCluster.serviceAccount.annotations | nindent 8}}
+            {{ toYaml .Values.pgCluster.serviceAccount.annotations | nindent 8 }}
       {{- end }}
   test-script.sh: |
     #!/bin/sh
 
+    CLUSTER_NAME="{{ .Values.pgCluster.name }}"
+    NAMESPACE="{{ .Values.pgCluster.namespace }}"
+    EXPECTED_POD_COUNT={{ .Values.pgCluster.instances }} # Define expected pod count
+
     # Make sure that a posgresql cluster with the same name is not already running
-    if kubectl get cluster.postgresql.cnpg.io {{ .Values.pgCluster.name }} -n {{ .Values.pgCluster.namespace }}; then
-      echo "A cluster with the name {{ .Values.pgCluster.name }} already exists in namespace {{ .Values.pgCluster.namespace }}. Please delete it before running the recovery test."
-      
+    if kubectl get clusters.postgresql.cnpg.io "${CLUSTER_NAME}" -n "${NAMESPACE}" > /dev/null 2>&1; then
+      echo "A cluster with the name ${CLUSTER_NAME} already exists in namespace ${NAMESPACE}. Please delete it before running the recovery test."
       exit 1
     fi
-    
+
     # create the recovery test cluster
-    kubectl apply -f /etc/config/pg-recovery-cluster.yaml
+    echo "Creating cluster ${CLUSTER_NAME} in namespace ${NAMESPACE}..."
+    if ! kubectl apply -f /etc/config/pg-recovery-cluster.yaml; then
+      echo "Failed to apply cluster manifest for ${CLUSTER_NAME}. Exiting."
+      exit 1
+    fi
 
-    # Wait for the cluster to be ready
-    sleep 600
+    # Wait for the cluster to be created and report its status
+    echo "Waiting for cluster ${CLUSTER_NAME} in namespace ${NAMESPACE} to be ready..."
+    if ! kubectl wait --for=condition=Ready clusters.postgresql.cnpg.io/"${CLUSTER_NAME}" -n "${NAMESPACE}" --timeout="${WAIT_TIMEOUT}"; then
+      echo "Cluster ${CLUSTER_NAME} did not become ready in 600 seconds."
+      echo "Investigate the cluster state. The script will not delete it."
+      exit 1 # Exit if cluster doesn't become ready
+    fi
+    echo "Cluster ${CLUSTER_NAME} is Ready."
 
-    echo "Running recovery test for cluster {{ .Values.pgCluster.name }}"
+    echo "Running recovery test for cluster ${CLUSTER_NAME}"
 
     # Execute tests until either those are successful or the timeout is reached
-    while [ $SECONDS -lt $TEST_TIMEOUT ]; do
-      # Check if the cluster is ready
-      if [[ "${kubectl get clusters.postgresql.cnpg.io -n {{ .Values.pgCluster.namespace }} {{ .Values.pgCluster.name }} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'}" == "True"]]; then
-        echo "{{ .Values.pgCluster.name }} successfully entered the 'Ready' state"
+    while [ $SECONDS -lt "$TEST_TIMEOUT" ]; do
+      # Check if the postgresql cluster's pods are in 'Ready' state
+      ready_pods_count=$(kubectl get pods -n "${NAMESPACE}" -l cnpg.io/cluster=${CLUSTER_NAME} -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' | grep -c True || true)
+      # The '|| true' ensures that if grep finds nothing (exit code 1), the script doesn't exit due to set -e (if it were set)
 
-        # If the postgresql cluster is ready, check if all the generated pods are in 'Ready' state
-        if [[ "${kubectl get pods -n {{ .Values.pgCluster.namespace }} -l cnpg.io/cluster={{ .Values.pgCluster.name }} -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}' | grep True | wc -w}" -eq .Values.pgCluster.instances ]]; then
-          echo "All pods for cluster {{ .Values.pgCluster.name }} are in 'Ready' state. Recovery test successful."
-          echo "Deleteting the recovery test cluster {{ .Values.pgCluster.name }}"
+      if [[ "${ready_pods_count}" -eq "${EXPECTED_POD_COUNT}" ]]; then
+        echo "All ${EXPECTED_POD_COUNT} pods for cluster ${CLUSTER_NAME} are in 'Ready' state. Recovery test successful."
+        echo "Deleting the recovery test cluster ${CLUSTER_NAME}"
 
-          # If the postgresql cluster's pods are ready, delete the cluster and end the test
-          kubectl delete cluster.postgresql.cnpg.io {{ .Values.pgCluster.name }} -n {{ .Values.pgCluster.namespace }}
-
-          exit 0
+        # If the postgresql cluster's pods are ready, delete the cluster and end the test
+        if ! kubectl delete clusters.postgresql.cnpg.io "${CLUSTER_NAME}" -n "${NAMESPACE}"; then
+          echo "Failed to delete cluster ${CLUSTER_NAME}. Please delete it manually."
+          exit 1 # Exit with error if deletion fails
         fi
+        echo "Cluster ${CLUSTER_NAME} deleted successfully."
+        exit 0
+      else
+        echo "Found ${ready_pods_count} ready pods out of ${EXPECTED_POD_COUNT} for cluster ${CLUSTER_NAME}. Waiting... ($SECONDS seconds elapsed)"
       fi
       
-      echo "Waiting for cluster {{ .Values.pgCluster.name }} to be ready since $SECONDS seconds..."
-      sleep 300
+      sleep 60 # Check more frequently
     done
 
     # If the timeout is reached, end the test without deleting the cluster to allow further investigation
-    echo "Recovery test completed"
+    echo "Timeout reached after $TEST_TIMEOUT seconds. Found ${ready_pods_count} ready pods out of ${EXPECTED_POD_COUNT}."
+    echo "Recovery test for ${CLUSTER_NAME} FAILED. The cluster will not be deleted to allow further investigation."
+    exit 1 # Explicitly exit with an error code on timeout

--- a/helm/pg-cluster-recovery-test/values.schema.json
+++ b/helm/pg-cluster-recovery-test/values.schema.json
@@ -8,6 +8,14 @@
                 "backoffLimit": {
                     "type": "integer"
                 },
+                "configMap": {
+                    "type": "object",
+                    "properties": {
+                        "defaultMode": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "containerSecurityContext": {
                     "type": "object",
                     "properties": {
@@ -84,6 +92,9 @@
                     }
                 },
                 "testTimeout": {
+                    "type": "integer"
+                },
+                "waitTimeout": {
                     "type": "integer"
                 }
             }

--- a/helm/pg-cluster-recovery-test/values.yaml
+++ b/helm/pg-cluster-recovery-test/values.yaml
@@ -9,9 +9,13 @@ cronjob:
     tag: 1.31.1
   
   schedule: "0 10 * * *" # Every day at 10:00 UTC
-  testTimeout: 1800 # 30 minutes
+  testTimeout: 1800 # 30 minutes. Time for the test to wait for the cluster's pods to be ready
+  waitTimeout: 600 # 10 minutes. Time for the test to wait for the cluster to be ready
   
   backoffLimit: 3
+
+  configMap:
+    defaultMode: 0550 # permissions for the configmap volume containing the test script and the pg cluster recovery template
 
   serviceAccount:
     create: true


### PR DESCRIPTION
The script is working as I manually tested it on `glippy`. NGL, I used Gemini's help me enhance the script.

The cnp is necessary for the pods generated by the postgresql cluster CR to work.

Now I only need to test the execution of the script by a pod with the same template as the one from the cronjob to make sure that everything works as intended.
