### PR TITLE
Add history limits cronjob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `failedJobsHistoryLimit` and `successfulJobsHistoryLimit` in the cronjob.
+
 ## [0.1.5] - 2025-06-30
 
 ### Changed

--- a/helm/pg-cluster-recovery-test/templates/cronjobs.yaml
+++ b/helm/pg-cluster-recovery-test/templates/cronjobs.yaml
@@ -47,3 +47,5 @@ spec:
               defaultMode: {{ .Values.cronjob.configMap.defaultMode }}
   terminationGracePeriodSeconds: 30
   schedule: {{ .Values.cronjob.schedule }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}

--- a/helm/pg-cluster-recovery-test/templates/pg-cluster-configmaps.yaml
+++ b/helm/pg-cluster-recovery-test/templates/pg-cluster-configmaps.yaml
@@ -9,7 +9,7 @@ data:
     kind: Cluster
     metadata:
       labels:
-        {{ tpl (include "labels.common" $) . | nindent 8 }}
+        {{- tpl (include "labels.common" $) . | nindent 8 }}
       name: {{ .Values.pgCluster.name }}
       namespace: {{ .Values.pgCluster.namespace }}
     spec:
@@ -52,7 +52,7 @@ data:
       serviceAccountTemplate:
         metadata:
           annotations:
-            {{ toYaml .Values.pgCluster.serviceAccount.annotations | nindent 8 }}
+            {{- toYaml .Values.pgCluster.serviceAccount.annotations | nindent 12 }}
       {{- end }}
   test-script.sh: |
     #!/bin/bash

--- a/helm/pg-cluster-recovery-test/values.schema.json
+++ b/helm/pg-cluster-recovery-test/values.schema.json
@@ -52,6 +52,9 @@
                         }
                     }
                 },
+                "failedJobsHistoryLimit": {
+                    "type": "integer"
+                },
                 "image": {
                     "type": "object",
                     "properties": {
@@ -93,6 +96,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "successfulJobsHistoryLimit": {
+                    "type": "integer"
                 },
                 "testTimeout": {
                     "type": "integer"

--- a/helm/pg-cluster-recovery-test/values.yaml
+++ b/helm/pg-cluster-recovery-test/values.yaml
@@ -17,6 +17,8 @@ cronjob:
   waitTimeout: 600s
 
   backoffLimit: 3
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
 
   configMap:
     # Permissions for the configmap volume containing the test script and the pg cluster recovery template


### PR DESCRIPTION
This will limit the number of zombie `Completed` pods that are stacking every day after each cronjob run.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
