### PR TITLE
small fixes in values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- fix values comment for `.cronjob.schedule`
+- increase default `.cronjob.waitTimeout` from 10min to 30min
+
 ## [0.4.1] - 2026-04-01
 
 ### Fixed

--- a/helm/pg-cluster-recovery-test/values.yaml
+++ b/helm/pg-cluster-recovery-test/values.yaml
@@ -9,12 +9,12 @@ cronjob:
     tag: 1.31.1
     pullPolicy: IfNotPresent
 
-  # Every day at 10:00 UTC
+  # 4 times a day: at 6:00 , 12:00, 18:00 and 00:00 UTC
   schedule: "0 */6 * * *"
   # 30 minutes. Time for the test to wait for the cluster's pods to be ready
   testTimeout: 1800
-  # 10 minutes. Time for the test to wait for the cluster to be ready
-  waitTimeout: 600s
+  # 30 minutes. Time for the test to wait for the cluster to be ready
+  waitTimeout: 1800s
 
   backoffLimit: 0
   failedJobsHistoryLimit: 1


### PR DESCRIPTION
- fix values comment for `.cronjob.schedule`
- increase default `.cronjob.waitTimeout` from 10min to 30min

Related to https://github.com/giantswarm/shared-configs/pull/607

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
