### PR TITLE
Fix rbac permission to read jobs definition for debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- fix values comment for `.cronjob.schedule`
-- increase default `.cronjob.waitTimeout` from 10min to 30min
+- Increase default `.cronjob.waitTimeout` from 10min to 30min
+- Improve test script log messages
+
+### Fixed
+
+- Fix values comment for `.cronjob.schedule`
+- Fix missing rbac permission to read jobs definition for debug logs
 
 ## [0.4.1] - 2026-04-01
 

--- a/helm/pg-cluster-recovery-test/files/test-script.sh
+++ b/helm/pg-cluster-recovery-test/files/test-script.sh
@@ -12,16 +12,16 @@ _run() {(
 
 # Make sure that a posgresql cluster with the same name is not already running
 if kubectl get clusters.postgresql.cnpg.io "${CLUSTER_NAME}" -n "${NAMESPACE}" > /dev/null 2>&1; then
-  echo "### A Cluster with the name ${CLUSTER_NAME} already exists in namespace ${NAMESPACE}. Please delete it before running the recovery test."
+  echo "### A PostgreSQL Cluster with the name ${CLUSTER_NAME} already exists in namespace ${NAMESPACE}. Please delete it before running the recovery test."
   exit 1
 fi
 
 # Create the recovery test cluster
-echo "### Creating Cluster ${CLUSTER_NAME} in namespace ${NAMESPACE}..."
+echo "### Creating PostgreSQL Cluster ${CLUSTER_NAME} in namespace ${NAMESPACE}..."
 # using kubectl patch in order to set the cluster name dynamically based on the pod hostname, and applying the manifest in one step
 if ! kubectl patch --dry-run=client -f /etc/config/pg-recovery-cluster.yaml --type merge --patch '{"metadata":{"name":"'"$CLUSTER_NAME"'"}}' -oyaml | kubectl apply -f -; then
 
-  echo "### Failed to apply Cluster manifest for ${CLUSTER_NAME}. Exiting."
+  echo "### Failed to apply PostgreSQL Cluster manifest for ${CLUSTER_NAME}. Exiting."
   exit 1
 fi
 
@@ -29,57 +29,59 @@ fi
 cleanup() {
   echo
   echo
-  echo "### Deleting the recovery test Cluster ${CLUSTER_NAME}"
+  echo "### Deleting the recovery test PostgreSQL Cluster ${CLUSTER_NAME}"
 
   # If the postgresql cluster's pods are ready, delete the cluster and end the test
   if ! _run kubectl delete clusters.postgresql.cnpg.io "${CLUSTER_NAME}" -n "${NAMESPACE}"; then
-    echo "### Failed to delete cluster ${CLUSTER_NAME}. Please delete it manually."
+    echo "### Failed to delete PostgreSQL Cluster ${CLUSTER_NAME}. Please delete it manually."
     exit 1 # Exit with error if deletion fails
   fi
-  echo "### Cluster ${CLUSTER_NAME} deleted successfully."
+  echo "### PostgreSQL Cluster ${CLUSTER_NAME} deleted successfully."
 
-  echo "### Deleting persistent volume claims for the ${CLUSTER_NAME} cluster"
+  echo "### Deleting persistent volume claims for the ${CLUSTER_NAME} PostgreSQL Cluster"
   if ! _run kubectl delete pvc -l "cnpg.io/cluster=${CLUSTER_NAME}" -n "${NAMESPACE}"; then
-    echo "### Failed to delete pvc for the ${CLUSTER_NAME} cluster. Please delete it manually."
+    echo "### Failed to delete persistent volume claims for the ${CLUSTER_NAME} PostgreSQL Cluster. Please delete it manually."
     exit 1 # Exit with error if deletion fails
   fi
-  echo "### Persistent volume claims for the ${CLUSTER_NAME} cluster deleted successfully."
+  echo "### Persistent volume claims for the ${CLUSTER_NAME} PostgreSQL Cluster deleted successfully."
 
   # The exit code is propagated from the main script, so if the cluster didn't become ready or the test failed, the script will exit with an error code after cleanup
 }
 trap cleanup EXIT
 
 # Wait for the cluster to be created and report its status
-echo "### Waiting for Cluster to be ready..."
+echo "### Waiting for PostgreSQL Cluster to be ready..."
 _run kubectl wait --for=condition=Ready "clusters.postgresql.cnpg.io/${CLUSTER_NAME}" -n "${NAMESPACE}" --timeout="${WAIT_TIMEOUT}"
 wait_exit_code=$?
 
 echo
-echo
-echo "### Printing Cluster resource:"
+echo "### Printing PostgreSQL Cluster resource:"
 _run kubectl describe clusters.postgresql.cnpg.io "${CLUSTER_NAME}" -n "${NAMESPACE}"
 
-echo "### Printing full-recovery Job resource:"
+echo
+echo "### Printing CNPG full-recovery Job resource:"
 _run kubectl describe job -l "cnpg.io/cluster=${CLUSTER_NAME}" -n "${NAMESPACE}"
 
 # Get the name of the last created full-recovery pod for the cluster
 last_full_recovery_pod_name="$(kubectl get po -l "cnpg.io/cluster=${CLUSTER_NAME}" -n "${NAMESPACE}" --sort-by='{.metadata.creationTimestamp}' -o jsonpath='{.items[-1:].metadata.name}')"
 
-echo "### Printing full-recovery Pod resource:"
+echo
+echo "### Printing CNPG full-recovery Pod resource:"
 _run kubectl describe pod "${last_full_recovery_pod_name}" -n "${NAMESPACE}"
 
-echo "### Printing full-recovery Pod Logs:"
+echo
+echo "### Printing CNPG full-recovery Pod Logs:"
 _run kubectl logs "pod/${last_full_recovery_pod_name}" --all-containers -n "${NAMESPACE}"
 echo
 echo
 
 if [[ $wait_exit_code -ne 0 ]]; then
-  echo "### Cluster ${CLUSTER_NAME} did not become ready in ${WAIT_TIMEOUT} seconds."
+  echo "### PostgreSQL Cluster ${CLUSTER_NAME} did not become ready in ${WAIT_TIMEOUT} seconds."
   echo "### Recovery test for ${CLUSTER_NAME} FAILED."
   exit 1 # Exit if cluster doesn't become ready
 fi
 
-echo "### Cluster ${CLUSTER_NAME} is Ready."
+echo "### PostgreSQL Cluster ${CLUSTER_NAME} is Ready."
 echo "### Running recovery tests..."
 
 # Execute tests until either those are successful or the timeout is reached
@@ -89,10 +91,10 @@ while [[ "$SECONDS" -lt "$TEST_TIMEOUT" ]]; do
   # The '|| true' ensures that if grep finds nothing (exit code 1), the script doesn't exit due to set -e (if it were set)
 
   if [[ "${ready_pods_count}" -eq "${EXPECTED_POD_COUNT}" ]]; then
-    echo "### All ${EXPECTED_POD_COUNT} Pods for Cluster ${CLUSTER_NAME} are in 'Ready' state. Recovery test successfully PASSED."
+    echo "### All ${EXPECTED_POD_COUNT} Pods for PostgreSQL Cluster ${CLUSTER_NAME} are in 'Ready' state. Recovery test successfully PASSED."
     exit 0
   else
-    echo "### Found ${ready_pods_count} ready Pods out of ${EXPECTED_POD_COUNT} for Cluster ${CLUSTER_NAME}. Waiting... ($SECONDS seconds elapsed)"
+    echo "### Found ${ready_pods_count} ready Pods out of ${EXPECTED_POD_COUNT} for PostgreSQL Cluster ${CLUSTER_NAME}. Waiting... ($SECONDS seconds elapsed)"
   fi
 
   sleep 60 # Check more frequently
@@ -100,5 +102,5 @@ done
 
 # If the timeout is reached, end the test without deleting the cluster to allow further investigation
 echo "### Timeout reached after $TEST_TIMEOUT seconds. Found ${ready_pods_count} ready Pods out of ${EXPECTED_POD_COUNT}."
-echo "### Recovery test for ${CLUSTER_NAME} FAILED."
+echo "### Recovery test for ${CLUSTER_NAME} PostgreSQL Cluster FAILED."
 exit 1 # Explicitly exit with an error code on timeout

--- a/helm/pg-cluster-recovery-test/files/test-script.sh
+++ b/helm/pg-cluster-recovery-test/files/test-script.sh
@@ -12,16 +12,16 @@ _run() {(
 
 # Make sure that a posgresql cluster with the same name is not already running
 if kubectl get clusters.postgresql.cnpg.io "${CLUSTER_NAME}" -n "${NAMESPACE}" > /dev/null 2>&1; then
-  echo "> A Cluster with the name ${CLUSTER_NAME} already exists in namespace ${NAMESPACE}. Please delete it before running the recovery test."
+  echo "### A Cluster with the name ${CLUSTER_NAME} already exists in namespace ${NAMESPACE}. Please delete it before running the recovery test."
   exit 1
 fi
 
 # Create the recovery test cluster
-echo "> Creating Cluster ${CLUSTER_NAME} in namespace ${NAMESPACE}..."
+echo "### Creating Cluster ${CLUSTER_NAME} in namespace ${NAMESPACE}..."
 # using kubectl patch in order to set the cluster name dynamically based on the pod hostname, and applying the manifest in one step
 if ! kubectl patch --dry-run=client -f /etc/config/pg-recovery-cluster.yaml --type merge --patch '{"metadata":{"name":"'"$CLUSTER_NAME"'"}}' -oyaml | kubectl apply -f -; then
 
-  echo "> Failed to apply Cluster manifest for ${CLUSTER_NAME}. Exiting."
+  echo "### Failed to apply Cluster manifest for ${CLUSTER_NAME}. Exiting."
   exit 1
 fi
 
@@ -29,58 +29,58 @@ fi
 cleanup() {
   echo
   echo
-  echo "> Deleting the recovery test Cluster ${CLUSTER_NAME}"
+  echo "### Deleting the recovery test Cluster ${CLUSTER_NAME}"
 
   # If the postgresql cluster's pods are ready, delete the cluster and end the test
   if ! _run kubectl delete clusters.postgresql.cnpg.io "${CLUSTER_NAME}" -n "${NAMESPACE}"; then
-    echo "> Failed to delete cluster ${CLUSTER_NAME}. Please delete it manually."
+    echo "### Failed to delete cluster ${CLUSTER_NAME}. Please delete it manually."
     exit 1 # Exit with error if deletion fails
   fi
-  echo "> Cluster ${CLUSTER_NAME} deleted successfully."
+  echo "### Cluster ${CLUSTER_NAME} deleted successfully."
 
-  echo "> Deleting persistent volume claims for the ${CLUSTER_NAME} cluster"
+  echo "### Deleting persistent volume claims for the ${CLUSTER_NAME} cluster"
   if ! _run kubectl delete pvc -l "cnpg.io/cluster=${CLUSTER_NAME}" -n "${NAMESPACE}"; then
-    echo "> Failed to delete pvc for the ${CLUSTER_NAME} cluster. Please delete it manually."
+    echo "### Failed to delete pvc for the ${CLUSTER_NAME} cluster. Please delete it manually."
     exit 1 # Exit with error if deletion fails
   fi
-  echo "> Persistent volume claims for the ${CLUSTER_NAME} cluster deleted successfully."
+  echo "### Persistent volume claims for the ${CLUSTER_NAME} cluster deleted successfully."
 
   # The exit code is propagated from the main script, so if the cluster didn't become ready or the test failed, the script will exit with an error code after cleanup
 }
 trap cleanup EXIT
 
 # Wait for the cluster to be created and report its status
-echo "> Waiting for Cluster to be ready..."
+echo "### Waiting for Cluster to be ready..."
 _run kubectl wait --for=condition=Ready "clusters.postgresql.cnpg.io/${CLUSTER_NAME}" -n "${NAMESPACE}" --timeout="${WAIT_TIMEOUT}"
 wait_exit_code=$?
 
 echo
 echo
-echo "> Printing Cluster resource:"
+echo "### Printing Cluster resource:"
 _run kubectl describe clusters.postgresql.cnpg.io "${CLUSTER_NAME}" -n "${NAMESPACE}"
 
-echo "> Printing full-recovery Job resource:"
+echo "### Printing full-recovery Job resource:"
 _run kubectl describe job -l "cnpg.io/cluster=${CLUSTER_NAME}" -n "${NAMESPACE}"
 
 # Get the name of the last created full-recovery pod for the cluster
 last_full_recovery_pod_name="$(kubectl get po -l "cnpg.io/cluster=${CLUSTER_NAME}" -n "${NAMESPACE}" --sort-by='{.metadata.creationTimestamp}' -o jsonpath='{.items[-1:].metadata.name}')"
 
-echo "> Printing full-recovery Pod resource:"
+echo "### Printing full-recovery Pod resource:"
 _run kubectl describe pod "${last_full_recovery_pod_name}" -n "${NAMESPACE}"
 
-echo "> Printing full-recovery Pod Logs:"
+echo "### Printing full-recovery Pod Logs:"
 _run kubectl logs "pod/${last_full_recovery_pod_name}" --all-containers -n "${NAMESPACE}"
 echo
 echo
 
 if [[ $wait_exit_code -ne 0 ]]; then
-  echo "> Cluster ${CLUSTER_NAME} did not become ready in ${WAIT_TIMEOUT} seconds."
-  echo "> Recovery test for ${CLUSTER_NAME} FAILED."
+  echo "### Cluster ${CLUSTER_NAME} did not become ready in ${WAIT_TIMEOUT} seconds."
+  echo "### Recovery test for ${CLUSTER_NAME} FAILED."
   exit 1 # Exit if cluster doesn't become ready
 fi
 
-echo "> Cluster ${CLUSTER_NAME} is Ready."
-echo "> Running recovery tests..."
+echo "### Cluster ${CLUSTER_NAME} is Ready."
+echo "### Running recovery tests..."
 
 # Execute tests until either those are successful or the timeout is reached
 while [[ "$SECONDS" -lt "$TEST_TIMEOUT" ]]; do
@@ -89,16 +89,16 @@ while [[ "$SECONDS" -lt "$TEST_TIMEOUT" ]]; do
   # The '|| true' ensures that if grep finds nothing (exit code 1), the script doesn't exit due to set -e (if it were set)
 
   if [[ "${ready_pods_count}" -eq "${EXPECTED_POD_COUNT}" ]]; then
-    echo "> All ${EXPECTED_POD_COUNT} Pods for Cluster ${CLUSTER_NAME} are in 'Ready' state. Recovery test successfully PASSED."
+    echo "### All ${EXPECTED_POD_COUNT} Pods for Cluster ${CLUSTER_NAME} are in 'Ready' state. Recovery test successfully PASSED."
     exit 0
   else
-    echo "> Found ${ready_pods_count} ready Pods out of ${EXPECTED_POD_COUNT} for Cluster ${CLUSTER_NAME}. Waiting... ($SECONDS seconds elapsed)"
+    echo "### Found ${ready_pods_count} ready Pods out of ${EXPECTED_POD_COUNT} for Cluster ${CLUSTER_NAME}. Waiting... ($SECONDS seconds elapsed)"
   fi
 
   sleep 60 # Check more frequently
 done
 
 # If the timeout is reached, end the test without deleting the cluster to allow further investigation
-echo "> Timeout reached after $TEST_TIMEOUT seconds. Found ${ready_pods_count} ready Pods out of ${EXPECTED_POD_COUNT}."
-echo "> Recovery test for ${CLUSTER_NAME} FAILED."
+echo "### Timeout reached after $TEST_TIMEOUT seconds. Found ${ready_pods_count} ready Pods out of ${EXPECTED_POD_COUNT}."
+echo "### Recovery test for ${CLUSTER_NAME} FAILED."
 exit 1 # Explicitly exit with an error code on timeout

--- a/helm/pg-cluster-recovery-test/templates/rbac.yaml
+++ b/helm/pg-cluster-recovery-test/templates/rbac.yaml
@@ -27,6 +27,12 @@ rules:
   - watch
   - list
 - apiGroups:
+  - "batch"
+  resources:
+  - jobs
+  verbs:
+  - get
+- apiGroups:
   - ""
   resources:
   - persistentvolumeclaims


### PR DESCRIPTION
This PR fixes an minor issue where the job definition could not be printed in the debug log due to a missing rbac permissions.

Actual error:

```
   > Printing full-recovery Job resource:
   + kubectl describe job -l
   cnpg.io/cluster=grafana-postgresql-recovery-test-29585520-9hrfp -n
   monitoring Error from server (Forbidden): jobs.batch is forbidden: User
   "system:serviceaccount:monitoring:grafana-postgresql-recovery-test" cannot
   list resource "jobs" in API group "batch" in the namesp ace "monitoring"
```

This PR also improve test script log messages
   - Change test shell script prefix from '>' to '###' for better visibility
   - Add 'PostgreSQL' to identify cluster CRs
   - Add 'CNPG' to identify full-recovery pods